### PR TITLE
Add `CL_FORK` env to create genesis at arbitrary forks (`phase0`, `altair`, `merge`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.17 as builder
-RUN git clone https://github.com/skylenet/eth2-testnet-genesis.git \
-    && cd eth2-testnet-genesis && git checkout faster-validator-creation \
+RUN git clone https://github.com/protolambda/eth2-testnet-genesis.git \
+    && cd eth2-testnet-genesis \
     && go install . \
     && go install github.com/protolambda/eth2-val-tools@latest
 
@@ -10,7 +10,7 @@ VOLUME ["/config", "/data"]
 EXPOSE 8000/tcp
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-        ca-certificates build-essential python python3-dev python3-pip gettext-base && \
+    ca-certificates build-essential python python3-dev python3-pip gettext-base && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Name | Default | Description
 ---- |-------- | ----
 SERVER_PORT | 8000 | Web server port
 CL_TIMESTAMP_DELAY_SECONDS | 300 | The consensus layer genesis timestamp will be the current time + CL_TIMESTAMP_DELAY_SECONDS
+CL_FORK | phase0 | Fork at genesis, one of `phase0, altair, merge`
 
 Besides that, you can also use ENV vars in your configuration files. These will be replaced during runtime.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 CL_ETH1_BLOCK="${CL_ETH1_BLOCK:-0x0000000000000000000000000000000000000000000000000000000000000000}"
 CL_TIMESTAMP_DELAY_SECONDS="${CL_TIMESTAMP_DELAY_SECONDS:-300}"
+CL_FORK="${CL_FORK:-phase0}"
 SERVER_PORT="${SERVER_PORT:-8000}"
 NOW=$(date +%s)
 CL_TIMESTAMP=$((NOW + CL_TIMESTAMP_DELAY_SECONDS))
@@ -40,14 +41,15 @@ gen_cl_config(){
         envsubst < /config/cl/config.yaml > /data/cl/config.yaml
         envsubst < /config/cl/mnemonics.yaml > $tmp_dir/mnemonics.yaml
         # Replace MIN_GENESIS_TIME on config
-        sed -i "s/^MIN_GENESIS_TIME:.*/MIN_GENESIS_TIME: ${CL_TIMESTAMP}/" /data/cl/config.yaml
+        sed "s/^MIN_GENESIS_TIME:.*/MIN_GENESIS_TIME: ${CL_TIMESTAMP}/" /data/cl/config.yaml > /tmp/config.yaml
+	    mv /tmp/config.yaml /data/cl/config.yaml
         # Create deposit_contract.txt and deploy_block.txt
         grep DEPOSIT_CONTRACT_ADDRESS /data/cl/config.yaml | cut -d " " -f2 > /data/cl/deposit_contract.txt
         echo "0" > /data/cl/deploy_block.txt
         # Envsubst mnemonics
         envsubst < /config/cl/mnemonics.yaml > $tmp_dir/mnemonics.yaml
         # Generate genesis
-        /usr/local/bin/eth2-testnet-genesis phase0 \
+        /usr/local/bin/eth2-testnet-genesis $CL_FORK \
         --config /data/cl/config.yaml \
         --eth1-block "${CL_ETH1_BLOCK}" \
         --mnemonics $tmp_dir/mnemonics.yaml \


### PR DESCRIPTION
- Pull `protolambda/eth2-testnet-genesis` instead of `skylenet/eth2-testnet-genesis` as the changes were merged from the latter to the former.
- Added `CL_FORK` environment variable to pass to `eth2-testnet-genesis` for genesis at forks other than `phase0`
- Workaround for a bug where `sed -i` fails for Docker on Mac with VirtioFS enabled (see https://github.com/docker/for-mac/issues/6277)
  *I know that's not necessary, but it alleviates some pain for Mac peoples without hurting others, so why not? :-)*
- Updated `README.md`

h/t to @michaelsproul for helping me debug: https://github.com/protolambda/eth2-testnet-genesis/issues/7