### PR TITLE
Update geth merge fork block config

### DIFF
--- a/apps/el-gen/genesis_geth.py
+++ b/apps/el-gen/genesis_geth.py
@@ -25,7 +25,7 @@ out = {
         "istanbulBlock":0,
         "berlinBlock":0,
         "londonBlock":0,
-        "mergeForkBlock":int(data['mergeForkBlock']),
+        "mergeNetsplitBlock":int(data['mergeForkBlock']),
         "terminalTotalDifficulty":int(data['terminal_total_difficulty'])
     },
     "alloc": {


### PR DESCRIPTION
Update merge for block config. Geth changed the config name [here](https://github.com/ethereum/go-ethereum/commit/41e75480df2a70265e9e364f100f9962e2972ec1#diff-10ff00a15ef58da7485fedeca3906c73cb236fde4b143a9d61601c63cbf1ffe8R360). 

Because of this mismatched, get node in [eth2-merge-kurtosis](https://github.com/kurtosis-tech/eth2-merge-kurtosis-module) which uses this generator does not generate correct fork id, which will disconnect nethermind's node, which is what I'm working on.