### PR TITLE
Fix `sed` for Docker on Mac

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,8 @@ gen_cl_config(){
         envsubst < /config/cl/mnemonics.yaml > $tmp_dir/mnemonics.yaml
         cp $tmp_dir/mnemonics.yaml /data/custom_config_data/mnemonics.yaml
         # Replace MIN_GENESIS_TIME on config
-        sed -i "s/^MIN_GENESIS_TIME:.*/MIN_GENESIS_TIME: ${GENESIS_TIMESTAMP}/" /data/custom_config_data/config.yaml
+        sed "s/^MIN_GENESIS_TIME:.*/MIN_GENESIS_TIME: ${GENESIS_TIMESTAMP}/" /data/custom_config_data/config.yaml > /tmp/config.yaml
+        mv /tmp/config.yaml /data/custom_config_data/config.yaml
         # Create deposit_contract.txt and deploy_block.txt
         grep DEPOSIT_CONTRACT_ADDRESS /data/custom_config_data/config.yaml | cut -d " " -f2 > /data/custom_config_data/deposit_contract.txt
         echo $DEPOSIT_CONTRACT_BLOCK > /data/custom_config_data/deploy_block.txt


### PR DESCRIPTION
Hi,

This change was previously accepted, but now reverted. (See https://github.com/skylenet/ethereum-genesis-generator/pull/7)

If there's no specific reason for this revert, can we merge this fix again?

We can't run ethereum-genesis-generator on Mac right now :D